### PR TITLE
Add commit hash to the tool output

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,4 @@ build --javabase=@bazel_tools//tools/jdk:host_jdk
 build --action_env=HOME
 build --workspace_status_command=./tools/mkstamp.sh
 build --host_force_python=PY2
+build --stamp

--- a/cmd/jpdownloader/BUILD.bazel
+++ b/cmd/jpdownloader/BUILD.bazel
@@ -14,6 +14,9 @@ go_library(
         "//vendor/github.com/juju/errors:go_default_library",
         "//vendor/github.com/mkmik/multierror:go_default_library",
     ],
+    x_defs = {
+        "gitCommit": "{STABLE_GIT_COMMIT}",
+    },
 )
 
 go_binary(

--- a/cmd/jpdownloader/main.go
+++ b/cmd/jpdownloader/main.go
@@ -22,6 +22,8 @@ const (
 )
 
 var (
+	gitCommit = "UNKNOWN"
+
 	workingDir = flag.String("working-dir", filepath.Join(os.Getenv("HOME"), ".jpr"), "plugins working directory, default to the HOME/.jenkins directory")
 	outputDir  = flag.String("output-dir", filepath.Join(os.Getenv("JENKINS_HOME"), "plugins"), "output directory, default to the JENKINS_HOME/plugins directory")
 	inputFile  = flag.String("input", "plugins.json.lock", "input file. You can use the output of jpresolver")
@@ -101,6 +103,8 @@ func validateFlags() error {
 
 func main() {
 	flag.Parse()
+
+	log.Printf("Version commit: %s\n", gitCommit)
 	if err := run(); err != nil {
 		log.Fatalf("%+v", err)
 	}

--- a/cmd/jpresolver/BUILD.bazel
+++ b/cmd/jpresolver/BUILD.bazel
@@ -18,6 +18,9 @@ go_library(
         "//vendor/github.com/juju/errors:go_default_library",
         "//vendor/github.com/mkmik/multierror:go_default_library",
     ],
+    x_defs = {
+        "gitCommit": "{STABLE_GIT_COMMIT}",
+    },
 )
 
 go_binary(

--- a/cmd/jpresolver/main.go
+++ b/cmd/jpresolver/main.go
@@ -27,6 +27,8 @@ const (
 )
 
 var (
+	gitCommit = "UNKNOWN"
+
 	inputFile  = flag.String("input", "plugins.json", "input file (.json, .jsonnet. .yaml or .yml)")
 	warFile    = flag.String("war", "", "jenkins war file")
 	optional   = flag.Bool("optional", false, "add optional dependencies to the output. It will allow plugins to run with all the expected features.")
@@ -195,6 +197,8 @@ func validateFlags() error {
 
 func main() {
 	flag.Parse()
+
+	log.Printf("Version commit: %s\n", gitCommit)
 	if err := run(); err != nil {
 		log.Fatalf("%+v", err)
 	}

--- a/tools/mkstamp.sh
+++ b/tools/mkstamp.sh
@@ -5,20 +5,14 @@
 #
 set -e
 
-# According to GitHub documentation GITHUB_ are reserved to internal use so we can rely on them
-# to set a proper tag when bazel runs inside GH actions.
-#
-# In this case, you can access to the build logs of an image by using the URL below.
-# https://github.com/bitnami-labs/jenkins-plugins-resolver/commit/COMMIT_SHA/checks
-#
-# Example:
-#
-# gcr.io/bitnami-labs/jenkins-plugins-resolver:master-dca6b4bfc97325ff175d575d30b4546e1bc99e92
-# https://github.com/bitnami-labs/jenkins-plugins-resolver/commit/dca6b4bfc97325ff175d575d30b4546e1bc99e92/checks
-#
-if [[ -n "$GITHUB_SHA" ]]; then
-    echo IMAGE_TAG "master-${GITHUB_SHA}"
-else
-    # We default something reasonable in case we run docker_push rules outside GitHub.
-    echo IMAGE_TAG "local-$(git rev-parse HEAD)"
+: "${BUILD_TAG:=local}"
+: "${GIT_COMMIT:=$(git rev-parse HEAD)}"
+
+# According to GitHub documentation CI is always set inside GH actions.
+# https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+if [[ -n "$CI" ]]; then
+    BUILD_TAG="master"
 fi
+
+echo IMAGE_TAG "${BUILD_TAG}-${GIT_COMMIT}"
+echo STABLE_GIT_COMMIT "${GIT_COMMIT}"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,16 +1,16 @@
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml
 # github.com/golang/protobuf v1.3.2
-github.com/golang/protobuf/proto
 github.com/golang/protobuf/jsonpb
+github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes/struct
 # github.com/google/go-jsonnet v0.14.0
 github.com/google/go-jsonnet
 github.com/google/go-jsonnet/ast
 github.com/google/go-jsonnet/astgen
 github.com/google/go-jsonnet/internal/errors
-github.com/google/go-jsonnet/internal/program
 github.com/google/go-jsonnet/internal/parser
+github.com/google/go-jsonnet/internal/program
 # github.com/hashicorp/go-version v1.2.0
 github.com/hashicorp/go-version
 # github.com/juju/errors v0.0.0-20190806202954-0232dcc7464d


### PR DESCRIPTION
I'd like to be able to identify binaries by commit hash. Therefore, I can use bazel ldflags to achieve it easily.