### PR TITLE
feat: Improve versions detection

### DIFF
--- a/pkg/utils/BUILD.bazel
+++ b/pkg/utils/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//vendor/github.com/google/go-jsonnet:go_default_library",
         "//vendor/github.com/hashicorp/go-version:go_default_library",
         "//vendor/github.com/juju/errors:go_default_library",
+        "//vendor/github.com/mkmik/multierror:go_default_library",
     ],
 )
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -126,7 +126,7 @@ func VersionLower(i string, j string) (bool, error) {
 func versionLower(i string, j string) (bool, error) {
 	vj, err := version.NewVersion(j)
 	if err != nil {
-		return false, errors.Errorf("unable to parse version (no-semver) %s: %s", j, err)
+		return false, errors.Errorf("unable to parse version %s: %s", j, err)
 	}
 
 	if i == "" && j != "" {
@@ -135,26 +135,26 @@ func versionLower(i string, j string) (bool, error) {
 
 	vi, err := version.NewVersion(i)
 	if err != nil {
-		return false, errors.Errorf("unable to parse version (no-semver) %s: %s", i, err)
+		return false, errors.Errorf("unable to parse version %s: %s", i, err)
 	}
 
 	return vi.LessThan(vj), nil
 }
 
-type VersionComparator func(i, j []string) (bool, error)
+type versionComparator func(i, j []string) (bool, error)
 
 // exceptionExpression contains a compiled regular expression and a function to test whether a version
 // matching it is lower than another vesrion.
 type exceptionExpression struct {
 	re *regexp.Regexp
-	fn VersionComparator
+	fn versionComparator
 }
 
 // The exceptions to manage
 var exceptionExpressions []*exceptionExpression
 
 // ExceptionRegexpsRaw are the raw regular expressions that we know are exceptions to standard version formats.
-var ExceptionRegexpsRaw = map[string]VersionComparator{
+var ExceptionRegexpsRaw = map[string]versionComparator{
 	// Exception found at https://plugins.jenkins.io/workflow-cps/#releases
 	// Example: 2648.va9433432b33c
 	`([0-9]+)\.v([a-z0-9]+)`: func(i, j []string) (bool, error) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,12 @@ package utils
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
@@ -9,11 +15,6 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/juju/errors"
 	"github.com/mkmik/multierror"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strconv"
 )
 
 // FileExists will test if a file exists

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -111,11 +111,15 @@ func TestVersionLower(t *testing.T) {
 		vj   string
 		want bool
 	}{
+		// Test standard versions
 		{"1.0.0", "1.0.0", false},
 		{"1.0.0", "2.0.0", true},
 		{"1.0.0", "1.1.0", true},
 		{"1.0.0", "1.0.1", true},
 		{"1.0.0", "1.0.0.1", true},
+		// Test exceptions
+		{"1108.v57edf648f5d4", "2648.va9433432b33c", true},
+		{"3108.v93ed", "2648.vbc92", false},
 	}
 	for _, tc := range testCases {
 		got, err := VersionLower(tc.vi, tc.vj)


### PR DESCRIPTION
The command used to generate the dependency graph for Jenkins plugins is returning the following error:
 
```
$ scripts/lock-plugins.sh -upgrade -p dynpipeline
...
2022/01/12 09:56:32 > downloading workflow-step-api:2.24 plugin...
2022/01/12 09:56:33 Recorded graph to disk: /Users/dvilladiego/.jpr/graph/a6f8ea3a00d960ff76692b3d9681a97ba7558543262dc5e6d8d47948b0c85c8c.graph
2022/01/12 09:56:33 2 errors occurred:
Error parsing version 1108.v57edf648f5d4: Malformed version: 1108.v57edf648f5d4
Error parsing version 2648.va9433432b33c: Malformed version: 2648.va9433432b33c
/home/runner/work/jenkins-plugins-resolver/jenkins-plugins-resolver/pkg/plugins/graph/locker.go:124:
/home/runner/work/jenkins-plugins-resolver/jenkins-plugins-resolver/cmd/jpresolver/main.go:117:
/home/runner/work/jenkins-plugins-resolver/jenkins-plugins-resolver/cmd/jpresolver/main.go:1
```

The problem seems to be that the jpresolver tool is not able to understand version numbers like `2648.va9433432b33c`  used by, for the example, the plugin https://plugins.jenkins.io/workflow-cps/#releases

This patch solves the problem by adding several detection strategies:

1. Standard detection
2. Exceptions detection
