### PR TITLE
fix: Fix use case in exception

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -157,8 +157,8 @@ var exceptionExpressions []*exceptionExpression
 // ExceptionRegexpsRaw are the raw regular expressions that we know are exceptions to standard version formats.
 var ExceptionRegexpsRaw = map[string]versionComparator{
 	// Exception found at https://plugins.jenkins.io/workflow-cps/#releases
-	// Example: 2648.va9433432b33c
-	`([0-9]+)\.v([a-z0-9]+)`: func(i, j []string) (bool, error) {
+	// Example: 2.40 is now 2648.va9433432b33c
+	`([0-9]+)\.v?([a-z0-9]+)`: func(i, j []string) (bool, error) {
 		xi, err := strconv.Atoi(i[1])
 		if err != nil {
 			return false, errors.Errorf("malformed version: %s in %v is not an integer", i[1], i)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -120,6 +120,7 @@ func TestVersionLower(t *testing.T) {
 		// Test exceptions
 		{"1108.v57edf648f5d4", "2648.va9433432b33c", true},
 		{"3108.v93ed", "2648.vbc92", false},
+		{"3108.v93ed", "2.40", false},
 	}
 	for _, tc := range testCases {
 		got, err := VersionLower(tc.vi, tc.vj)


### PR DESCRIPTION
In a previous PR I missed the edge case of an exception with a previous version format. This patch covers the situation.